### PR TITLE
Include TLS functionality

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -114,7 +114,7 @@ pub fn build(b: *std.Build) !void {
     for (headers) |h| lib.installHeader(h, std.fs.path.basename(h));
 
     // Include OpenSSL, as it is forced to be expected in the TLS C files
-    lib.linkSystemLibrary("openssl");
+    lib.linkSystemLibrary("ssl");
 
     // This declares intent for the library to be installed into the standard
     // location when the user invokes the "install" step (the default step when

--- a/build.zig
+++ b/build.zig
@@ -113,7 +113,7 @@ pub fn build(b: *std.Build) !void {
     };
     for (headers) |h| lib.installHeader(h, std.fs.path.basename(h));
 
-    // This onboards TLS functionality by including and activating openssl
+    // This onboards TLS functionality by linking openssl
     lib.linkSystemLibrary("ssl");
     lib.linkSystemLibrary("crypto");
 

--- a/build.zig
+++ b/build.zig
@@ -38,6 +38,8 @@ pub fn build(b: *std.Build) !void {
     if (target.getAbi() == .musl)
         try flags.append("-D_LARGEFILE64_SOURCE");
 
+    try flags.append("-DHAVE_OPENSSL -DFIO_TLS_FOUND");
+
     ////// TODO DELETEME     exe.addIncludePath(.{ .path = tracy_path });
     ////// TODO DELETEME     exe.addCSourceFile(.{ .file = .{ .path = client_cpp }, .flags = tracy_c_flags });
 
@@ -48,6 +50,7 @@ pub fn build(b: *std.Build) !void {
     lib.addIncludePath(.{ .path = "lib/facil/cli" });
     lib.addIncludePath(.{ .path = "lib/facil/http" });
     lib.addIncludePath(.{ .path = "lib/facil/http/parsers" });
+    lib.addIncludePath(.{ .path = "lib/facil/tls" });
 
     // C source files
     lib.addCSourceFiles(.{
@@ -68,6 +71,8 @@ pub fn build(b: *std.Build) !void {
             "lib/facil/fiobj/fiobject.c",
             "lib/facil/fiobj/fiobj_mustache.c",
             "lib/facil/cli/fio_cli.c",
+            "lib/facil/tls/fio_tls_openssl.c",
+            "lib/facil/tls/fio_tls_missing.c",
         },
         .flags = flags.items,
     });
@@ -103,20 +108,12 @@ pub fn build(b: *std.Build) !void {
         "lib/facil/http/http.h",
         "lib/facil/http/http1.h",
         "lib/facil/http/websockets.h",
+        "lib/facil/tls/fio_tls.h",
         "lib/facil/fio.h",
     };
     for (headers) |h| lib.installHeader(h, std.fs.path.basename(h));
 
     // This onboards TLS functionality by including and activating openssl
-    lib.addIncludePath(.{ .path = "lib/facil/tls" });
-    lib.installHeader("lib/facil/tls/fio_tls.h", std.fs.path.basename("lib/facil/tls/fio_tls.h"));
-    lib.addCSourceFiles(.{
-        .files = &.{
-            "lib/facil/tls/fio_tls_openssl.c",
-            "lib/facil/tls/fio_tls_missing.c",
-        },
-        .flags = &[_][]const u8{"-DHAVE_OPENSSL -DFIO_TLS_FOUND"},
-    });
     lib.linkSystemLibrary("ssl");
     lib.linkSystemLibrary("crypto");
 

--- a/build.zig
+++ b/build.zig
@@ -38,6 +38,8 @@ pub fn build(b: *std.Build) !void {
     if (target.getAbi() == .musl)
         try flags.append("-D_LARGEFILE64_SOURCE");
 
+    try flags.append("-DHAVE_OPENSSL -DFIO_TLS_FOUND");
+
     ////// TODO DELETEME     exe.addIncludePath(.{ .path = tracy_path });
     ////// TODO DELETEME     exe.addCSourceFile(.{ .file = .{ .path = client_cpp }, .flags = tracy_c_flags });
 
@@ -69,8 +71,8 @@ pub fn build(b: *std.Build) !void {
             "lib/facil/fiobj/fiobject.c",
             "lib/facil/fiobj/fiobj_mustache.c",
             "lib/facil/cli/fio_cli.c",
-            "lib/facil/tls/fio_tls_missing.c",
             "lib/facil/tls/fio_tls_openssl.c",
+            "lib/facil/tls/fio_tls_missing.c",
         },
         .flags = flags.items,
     });

--- a/build.zig
+++ b/build.zig
@@ -48,6 +48,7 @@ pub fn build(b: *std.Build) !void {
     lib.addIncludePath(.{ .path = "lib/facil/cli" });
     lib.addIncludePath(.{ .path = "lib/facil/http" });
     lib.addIncludePath(.{ .path = "lib/facil/http/parsers" });
+    lib.addIncludePath(.{ .path = "lib/facil/tls" });
 
     // C source files
     lib.addCSourceFiles(.{
@@ -68,6 +69,8 @@ pub fn build(b: *std.Build) !void {
             "lib/facil/fiobj/fiobject.c",
             "lib/facil/fiobj/fiobj_mustache.c",
             "lib/facil/cli/fio_cli.c",
+            "lib/facil/tls/fio_tls_missing.c",
+            "lib/facil/tls/fio_tls_openssl.c",
         },
         .flags = flags.items,
     });
@@ -94,7 +97,7 @@ pub fn build(b: *std.Build) !void {
         "lib/facil/fiobj/fiobj_str.h",
         "lib/facil/fiobj/fiobj.h",
         "lib/facil/fiobj/fio_siphash.h",
-        // "lib/facil/tls/fio_tls.h",
+        "lib/facil/tls/fio_tls.h",
         "lib/facil/cli/fio_cli.h",
         "lib/facil/http/parsers/hpack.h",
         "lib/facil/http/parsers/websocket_parser.h",

--- a/build.zig
+++ b/build.zig
@@ -111,6 +111,9 @@ pub fn build(b: *std.Build) !void {
     };
     for (headers) |h| lib.installHeader(h, std.fs.path.basename(h));
 
+    // Include OpenSSL, as it is forced to be expected in the TLS C files
+    lib.linkSystemLibrary("openssl");
+
     // This declares intent for the library to be installed into the standard
     // location when the user invokes the "install" step (the default step when
     // running `zig build`).

--- a/build.zig
+++ b/build.zig
@@ -38,6 +38,7 @@ pub fn build(b: *std.Build) !void {
     if (target.getAbi() == .musl)
         try flags.append("-D_LARGEFILE64_SOURCE");
 
+    // Force the acceptance of OpenSSL
     try flags.append("-DHAVE_OPENSSL -DFIO_TLS_FOUND");
 
     ////// TODO DELETEME     exe.addIncludePath(.{ .path = tracy_path });
@@ -112,9 +113,6 @@ pub fn build(b: *std.Build) !void {
         "lib/facil/fio.h",
     };
     for (headers) |h| lib.installHeader(h, std.fs.path.basename(h));
-
-    // Include OpenSSL, as it is forced to be expected in the TLS C files
-    lib.linkSystemLibrary("ssl");
 
     // This declares intent for the library to be installed into the standard
     // location when the user invokes the "install" step (the default step when

--- a/lib/facil/tls/fio_tls_missing.c
+++ b/lib/facil/tls/fio_tls_missing.c
@@ -4,6 +4,7 @@ License: MIT
 
 Feel free to copy, use and enjoy according to the license provided.
 */
+#if HAVE_OPENSSL
 #include <fio.h>
 
 /**
@@ -632,4 +633,5 @@ void FIO_TLS_WEAK fio_tls_destroy(fio_tls_s *tls) {
   free(tls);
 }
 
+#endif /* Library compiler flags */
 #endif /* Library compiler flags */

--- a/lib/facil/tls/fio_tls_missing.c
+++ b/lib/facil/tls/fio_tls_missing.c
@@ -24,7 +24,7 @@ Feel free to copy, use and enjoy according to the license provided.
 #define REQUIRE_LIBRARY()
 #define FIO_TLS_WEAK
 
-/* TODO: delete me! */
+/* TODO: delete me! *
 #undef FIO_TLS_WEAK
 #define FIO_TLS_WEAK __attribute__((weak))
 #if !FIO_IGNORE_TLS_IF_MISSING

--- a/lib/facil/tls/fio_tls_missing.c
+++ b/lib/facil/tls/fio_tls_missing.c
@@ -4,7 +4,6 @@ License: MIT
 
 Feel free to copy, use and enjoy according to the license provided.
 */
-#if HAVE_OPENSSL
 #include <fio.h>
 
 /**
@@ -633,5 +632,4 @@ void FIO_TLS_WEAK fio_tls_destroy(fio_tls_s *tls) {
   free(tls);
 }
 
-#endif /* Library compiler flags */
 #endif /* Library compiler flags */

--- a/lib/facil/tls/fio_tls_missing.c
+++ b/lib/facil/tls/fio_tls_missing.c
@@ -24,7 +24,7 @@ Feel free to copy, use and enjoy according to the license provided.
 #define REQUIRE_LIBRARY()
 #define FIO_TLS_WEAK
 
-/* TODO: delete me! *
+/* TODO: delete me! */
 #undef FIO_TLS_WEAK
 #define FIO_TLS_WEAK __attribute__((weak))
 #if !FIO_IGNORE_TLS_IF_MISSING

--- a/lib/facil/tls/fio_tls_missing.c
+++ b/lib/facil/tls/fio_tls_missing.c
@@ -31,7 +31,7 @@ Feel free to copy, use and enjoy according to the license provided.
 #undef REQUIRE_LIBRARY
 #define REQUIRE_LIBRARY()                                                      \
   FIO_LOG_FATAL("No supported SSL/TLS library available.");                    \
-  exit(-1);
+  exit(202);
 #endif
 /* STOP deleting after this line */
 
@@ -166,9 +166,14 @@ FIO_FUNC inline alpn_s *alpn_find(fio_tls_s *tls, char *name, size_t len) {
 
 /** Adds an ALPN data object to the ALPN "list" (set) */
 FIO_FUNC inline void alpn_add(
-    fio_tls_s *tls, const char *protocol_name,
-    void (*on_selected)(intptr_t uuid, void *udata_connection, void *udata_tls),
-    void *udata_tls, void (*on_cleanup)(void *udata_tls)) {
+    fio_tls_s *tls, 
+    const char *protocol_name,
+    void (*on_selected)(
+        intptr_t uuid, 
+        void *udata_connection, 
+        void *udata_tls),
+    void *udata_tls, 
+    void (*on_cleanup)(void *udata_tls)) {
   alpn_s tmp = {
       .name = FIO_STR_INIT_STATIC(protocol_name),
       .on_selected = on_selected,
@@ -514,7 +519,7 @@ void FIO_TLS_WEAK fio_tls_cert_add(fio_tls_s *tls, const char *server_name,
 file_missing:
   FIO_LOG_FATAL("TLS certificate file missing for either %s or %s or both.",
                 key, cert);
-  exit(-1);
+  exit(203);
 }
 
 /**
@@ -575,7 +580,7 @@ void FIO_TLS_WEAK fio_tls_trust(fio_tls_s *tls, const char *public_cert_file) {
   return;
 file_missing:
   FIO_LOG_FATAL("TLS certificate file missing for %s ", public_cert_file);
-  exit(-1);
+  exit(204);
 }
 
 /**

--- a/lib/facil/tls/fio_tls_openssl.c
+++ b/lib/facil/tls/fio_tls_openssl.c
@@ -157,9 +157,14 @@ FIO_FUNC inline alpn_s *alpn_find(fio_tls_s *tls, char *name, size_t len) {
 
 /** Adds an ALPN data object to the ALPN "list" (set) */
 FIO_FUNC inline void alpn_add(
-    fio_tls_s *tls, const char *protocol_name,
-    void (*on_selected)(intptr_t uuid, void *udata_connection, void *udata_tls),
-    void *udata_tls, void (*on_cleanup)(void *udata_tls)) {
+    fio_tls_s *tls, 
+    const char *protocol_name,
+    void (*on_selected)(
+        intptr_t uuid, 
+        void *udata_connection, 
+        void *udata_tls),
+    void *udata_tls, 
+    void (*on_cleanup)(void *udata_tls)) {
   alpn_s tmp = {
       .name = FIO_STR_INIT_STATIC(protocol_name),
       .on_selected = on_selected,
@@ -889,7 +894,7 @@ void FIO_TLS_WEAK fio_tls_cert_add(fio_tls_s *tls, const char *server_name,
 file_missing:
   FIO_LOG_FATAL("TLS certificate file missing for either %s or %s or both.",
                 key, cert);
-  exit(-1);
+  exit(200);
 }
 
 /**
@@ -952,7 +957,7 @@ void FIO_TLS_WEAK fio_tls_trust(fio_tls_s *tls, const char *public_cert_file) {
   return;
 file_missing:
   FIO_LOG_FATAL("TLS certificate file missing for %s ", public_cert_file);
-  exit(-1);
+  exit(201);
 }
 
 /**

--- a/lib/facil/tls/fio_tls_openssl.c
+++ b/lib/facil/tls/fio_tls_openssl.c
@@ -6,7 +6,7 @@ Feel free to copy, use and enjoy according to the license provided.
 */
 #include <fio.h>
 
-/**
+/*
  * This implementation of the facil.io SSL/TLS wrapper API wraps the OpenSSL API
  * to provide TLS 1.2 and TLS 1.3 to facil.io applications.
  *
@@ -14,7 +14,7 @@ Feel free to copy, use and enjoy according to the license provided.
  */
 #include "fio_tls.h"
 
-#if HAVE_OPENSSL
+//#if HAVE_OPENSSL
 #include <openssl/bio.h>
 #include <openssl/err.h>
 #include <openssl/ssl.h>
@@ -1009,4 +1009,4 @@ void FIO_TLS_WEAK fio_tls_destroy(fio_tls_s *tls) {
   free(tls);
 }
 
-#endif /* Library compiler flags */
+//#endif /* Library compiler flags */


### PR DESCRIPTION
Adds relevant TLS headers, includes, and options to build.zig file. Thus, exposing TLS functionality via OpenSSL. 

This causes OpenSSL to be a hard requirement. 